### PR TITLE
file[0] should be files[0]

### DIFF
--- a/lib/testee.js
+++ b/lib/testee.js
@@ -79,7 +79,7 @@ var test = function (file, configuration, callback) {
 		result[server.config.token] = token;
 		return result;
 	};
-	var server = createServer(file[0], config);
+	var server = createServer(files[0], config);
 
 	server.on('serverError', function(error, critical) {
 		if(critical) {


### PR DESCRIPTION
There's a typo in lib/testee.js: https://github.com/bitovi/testee.js/blob/master/lib/testee.js#L82

We currently convert the parameter "file" to an array if it is not, however on line 82 fail to use our newly modified variable.
