### PR TITLE
On timeout, call the callback with an error

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -114,7 +114,7 @@ _.extend(TestServer.prototype, {
 		var self = this;
 		var timeout = setTimeout(function() {
 			self.error(new Error('No test started within the timeout of ' + self.config.timeout + ' seconds.'),
-				'Server', true);
+				'Server', false);
 		}, self.config.timeout * 1000);
 
 		self.emit('registering', token, instance);

--- a/lib/testee.js
+++ b/lib/testee.js
@@ -92,6 +92,8 @@ var test = function (file, configuration, callback) {
 	server.on('serverError', function(error, critical) {
 		if(critical) {
 			process.exit();
+		} else {
+			callback(error);
 		}
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,25 @@
+var expect = require('expect.js');
+var testee = require('../lib/testee');
+
+describe('Testee', function () {
+
+	it('Should return an error when opening a file that doesn\'t exist',
+		function(done) {
+			// Silence the console so this doesn't appear to be an error.
+			var log = console.log;
+			var error = console.error;
+			console.log = function(){};
+			console.error = function(){};
+
+			testee.test('some/file/fake.html', {
+				timeout: 1,
+			}, function(err) {
+				console.log = log;
+				console.error = error;
+
+				expect(err).to.be.an(Error);
+				done();
+			});
+		});
+
+});


### PR DESCRIPTION
Previously timeouts were being treated as a critical error and therefore `process.exit()` was being called. This would prevent the Grunt task from ever failing. The fix is to make timeouts be non-critical, allowing the application to handle errors properly.
