### PR TITLE
Log the browser's stdout and stderr

### DIFF
--- a/lib/testee.js
+++ b/lib/testee.js
@@ -121,6 +121,20 @@ var test = function (file, configuration, callback) {
 							return callback(error);
 						}
 
+						if(config.verbose) {
+							var process = instance.process;
+							var stdout = process.stdout;
+							var stderr = process.stderr;
+
+							[stdout, stderr].forEach(function(stream, idx) {
+								var which = idx === 0 ? 'stdout'  : 'stderr';
+								stream.setEncoding('utf8');
+								stream.on('data', function(data) {
+									logger.debug('Browser', which + ':', data);
+								});
+							});
+						}
+
 						// Register the tokens
 						server.register(token, instance);
 						instance.on('testing', function (remoteReporter) {


### PR DESCRIPTION
Useful for debugging, Phantom in particular prints errors to stdout. Will submit a PR.
