### PR TITLE
Upgrade socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "commander": "~1.0.0",
     "winston": "~0.6.0",
     "mocha": "1.4.2",
-    "socket.io": "~0.9.6",
+    "socket.io": "^1.0.6",
     "connect": "~1.9.0",
     "underscore": "*",
     "async": "~0.2.7",


### PR DESCRIPTION
Socket.io < 1.0 doesn't play well with RequireJS. As seen here:
http://stackoverflow.com/questions/19334224/error-loading-socket-io-with-requirejs

1.0 fixes it.
