### PR TITLE
Catch errors when proxying and end the request.

### DIFF
--- a/lib/host/proxy.js
+++ b/lib/host/proxy.js
@@ -6,6 +6,10 @@ exports.http = function(root, settings) {
   var proxy = httpProxy.createProxyServer(settings.proxy || {});
   var port = root.port ? ':' + root.port : '';
 
+  proxy.on('error', function(err, req, res) {
+    res.end();
+  });
+  
   return function(req, res) {
     debug('HTTP proxying file', req.url);
     // If routing to a server on another domain, the hostname in the request must be changed.


### PR DESCRIPTION
Fixes an error that does not close proxied requests when they error.