### PR TITLE
Make sure all server connections are destroyed so Testee does not hang

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -24,11 +24,29 @@ exports.create = function(options) {
   // Uses the API server as a middleware on the `api/` route
   var host = hosting(options).use('/api', app);
   var oldListen = host.listen;
+  var connectionId = 0;
+  var connections = {};
 
   host.listen = function() {
     var server = oldListen.apply(this, arguments);
     app.setup(server);
     server.api = app;
+    //Track all connections, remove them when the are closed.
+    server.on('connection', function(conn){
+        var key = connectionId++;
+        connections[key] = conn;
+        conn.on('close', function(){
+            delete connections[key];
+        });
+    });
+    //Any open connection will be destroyed
+    server.destroy = function(cb){
+        server.close(cb || function(){});
+        for(var key in connections) {
+            connections[key].destroy();
+            delete connections[key];
+        }
+    };
     return server;
   };
 

--- a/lib/testee.js
+++ b/lib/testee.js
@@ -168,10 +168,7 @@ _.extend(Testee.prototype, {
 
     if(this.server) {
       debug('closing server');
-      // Todo this does take a callback but sometimes
-      // simply never returns even when cleanly shutting down
-      // all connections
-      this.server.close();
+      this.server.destroy();
     }
 
     return Q();


### PR DESCRIPTION
I've been using Testee with Gulp and noticed my Gulp task always hung after the tests had completed. Gulp would report the task as complete but it would not exit the process.

After some SO surfing I decided to check if the server used by Testee/Feathers had open connections when the tests completed and sure enough there were consistently 12 connections left open when [`server.close`](https://github.com/bitovi/testee/blob/master/lib/testee.js#L174) was called.

My fix is to track connections that are opened and provide a destroy method that will close any open connections and call `server.close`.