### PR TITLE
Istanbul coverage options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ testee.log
 run.js
 
 client/components
+
+test/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
+sudo: false
 language: node_js
 script: node_modules/.bin/bower install && npm test
 node_js:
   - "0.10"
+  - "node"
+  - "iojs"
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
         jshintrc: '.jshintrc'
       },
       lib: ['lib/**/*.js', 'Gruntfile.js'],
-      test: 'test/**/*.js'
+      test: ['test/**/*.js', '!test/coverage/**/*.js']
     },
 
     release: {},
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
       options: {
         timeout: 30000
       },
-      all: ['test/**/*.js']
+      all: ['test/**/*.js', '!test/coverage/**/*.js']
     },
 
     testee: {

--- a/README.md
+++ b/README.md
@@ -233,6 +233,18 @@ in a CI environment (outputting XUnit logs) could look like this:
 }
 ```
 
+### Code Coverage
+
+The `coverage` options is used to instrument and report code coverage using [Istanbul](https://github.com/gotwarlost/istanbul). There are several options available for configuring how code coverage is reported:
+
+__`reporters` *{Array}*__<br />
+The type of reporter(s) to use. Multiple formats are available, including `text` and `html`.
+
+__`dir` *{String}*__<br />
+The directory where the coverage data should be written. `text` reports will be written to the console.
+
+__`ignore` *{Array}*__<br />
+List of regex patterns to match files that should be ignored by coverage instrumentation and reporting.
 
 ### Localhost tunneling
 
@@ -284,10 +296,12 @@ module.exports = function(grunt) {
         root: 'public',
         reporter: 'Spec'
       },
-      phantom: ['test/index.html'],
       coverage: {
         options: {
+          browsers: ['phantom'],
           coverage: {
+            dir: 'test/coverage/',
+            reporters: ['text', 'html'],
             ignore: ['bower_components/', 'test/']
           }
         },

--- a/examples/jasmine/test.js
+++ b/examples/jasmine/test.js
@@ -36,7 +36,7 @@ describe('Blog post test', function () {
 
 	it('Should be published at the current time', function () {
 		var now = new Date(),
-			post = new BlogPost('Hello', 'Hello world');
+			post = new BlogPost('Hello', 'Hello world', now);
 		expect(post.date.getTime()).toBe(now.getTime());
 	});
 

--- a/examples/mocha/test.js
+++ b/examples/mocha/test.js
@@ -2,7 +2,7 @@ describe('BlogPost test', function() {
 
 	it('Should be published at the current time', function() {
 		var now = new Date(),
-			post = new BlogPost('Hello', 'Hello world');
+			post = new BlogPost('Hello', 'Hello world', now);
 		assert(post.date.getTime() == now.getTime());
 	});
 

--- a/examples/qunit/test.js
+++ b/examples/qunit/test.js
@@ -12,10 +12,11 @@ test('Unpublished post throws exception', function() {
 
 test('Generates HTML', function() {
   stop();
-  var newpost = new BlogPost('Hello', 'Hello world');
+  var now = new Date();
+  var newpost = new BlogPost('Hello', 'Hello world', now);
   newpost.publish(function(post) {
     equal(post.toString(), "<h1>Hello</h1>" +
-      "<h6>Published on " + new Date().toString() + "</h6>" +
+      "<h6>Published on " + now.toString() + "</h6>" +
       "<p>Hello world</p>", 'Generated expected HTML');
     start();
   });

--- a/lib/host/coverage.js
+++ b/lib/host/coverage.js
@@ -6,6 +6,8 @@ var url = require('url');
 var istanbul = require('istanbul');
 var instrumenter = new istanbul.Instrumenter();
 var injector = require('connect-injector');
+var path = require('path');
+var mime = require('mime-types');
 
 // Returns a middleware that instruments JavaScript files for code coverage
 module.exports = function(config) {
@@ -17,7 +19,7 @@ module.exports = function(config) {
       var regex = pattern instanceof RegExp ? pattern : new RegExp(pattern);
       return regex.test(req.url);
     });
-    var contentType = res.getHeader('content-type');
+    var contentType = res.getHeader('content-type') || mime.contentType(path.extname(url.parse(req.url).pathname));
 
     return contentType && (contentType.indexOf('application/javascript') === 0 ||
       contentType.indexOf('application/x-javascript') === 0) &&

--- a/lib/host/inject.js
+++ b/lib/host/inject.js
@@ -1,11 +1,14 @@
 var injector = require('connect-injector');
 var debug = require('debug')('testee:html-injector');
+var path = require('path');
+var url = require('url');
+var mime = require('mime-types');
 
 // Returns a middleware that injects the SocketIO JavaScript
 // and a link to the clients side adapters into any HTML file
 module.exports = function(configuration) {
   return injector(function(req, res) {
-    var header = res.getHeader('content-type');
+    var header = res.getHeader('content-type') || mime.contentType(path.extname(url.parse(req.url).pathname));
     if(res._header) {
       var matches = res._header.match(/content-type:[\s*](.*)/i);
       header = matches && matches[1];

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -12,7 +12,7 @@ var testProperties = ['async', 'sync', 'timedOut', 'pending', 'file', 'duration'
 
 // The reporter listens to service events and reports it to the command line using
 // any of the Mocha reporters.
-function Reporter(MochaReporter, coverage) {
+function Reporter(MochaReporter, coverage, root) {
   MochaReporter = typeof MochaReporter !== 'string' ? MochaReporter : mocha.reporters[MochaReporter];
 
   // The event emitter used to emit the final events
@@ -29,6 +29,8 @@ function Reporter(MochaReporter, coverage) {
   this.errors = [];
   // Options for reporting code coverage
   this.coverage = coverage;
+  // Option for root path
+  this.root = root;
 }
 
 _.extend(Reporter.prototype, {
@@ -241,6 +243,7 @@ _.extend(Reporter.prototype, {
   reportCoverage: function(data) {
     debug('reporting code coverage', data);
     var options = this.coverage;
+    var root = this.root;
     var reporter = new istanbul.Reporter(false, options.dir);
     var collector = new istanbul.Collector();
     var formats = options.reporters ? _.toArray(options.reporters) : ['text'];
@@ -249,6 +252,11 @@ _.extend(Reporter.prototype, {
     if(formats.indexOf('text') !== -1) {
       console.log('\n');
     }
+
+    // modify path to match the path of files instrumented by Istanbul
+    _.forEach(data.coverage, function (coverage) {
+        coverage.path = (coverage.path[0] === '/') ? root + coverage.path : root + '/' + coverage.path;
+    });
 
     collector.add(data.coverage);
     reporter.addAll(formats);

--- a/lib/testee.js
+++ b/lib/testee.js
@@ -25,7 +25,7 @@ _.extend(Testee.prototype, {
 
     var self = this;
     // We need to initialize the reporter first (in case of errors)
-    var reporter = new Reporter(this.options.reporter, this.options.coverage);
+    var reporter = new Reporter(this.options.reporter, this.options.coverage, this.options.root);
     // A deferred that runs the initialization flow
     var flow = this.startServer()
       // Sets up the reporter and binds Feathers service events to it

--- a/package.json
+++ b/package.json
@@ -53,8 +53,10 @@
     "istanbul": "^0.3.2",
     "launchpad": "^0.4.0",
     "lodash": "^2.4.1",
+    "mime-types": "^2.1.6",
     "miner": "^0.2.1",
     "mocha": "^1.20.1",
+    "path": "^0.11.14",
     "q": "^1.0.1",
     "testee-client": "^0.3.0",
     "useragent": "^2.0.9"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "lib/testee.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test --stack"
   },
   "engines": {
     "node": "~0.10"
@@ -36,7 +36,9 @@
     }
   ],
   "devDependencies": {
+    "async": "^1.4.2",
     "bower": "^1.3.12",
+    "del": "^2.0.2",
     "grunt": "~ 0.4.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -1,0 +1,60 @@
+var assert = require('assert');
+var path = require('path');
+var del = require('del');
+var fs = require('fs');
+var async = require('async');
+var testee = require('../lib/testee');
+
+describe('Coverage', function() {
+  var config = {
+    root: path.join(__dirname, '..', 'examples'),
+    reporter: 'Dot',
+    coverage: {
+      dir: 'test/coverage/',
+      reporters: [ 'html' ],
+      ignore: [
+        "bower_components"
+      ]
+    }
+  };
+  
+  it('QUnit example', function(done) {
+    del([ 'test/coverage' ]).then(function () {
+      testee.test([ 'qunit/index.html' ], [ 'firefox' ], config).fail(function(error) {
+        assert.equal(error.message, 'There were 0 general errors and 1 total test failures.');
+
+        async.map([ 'test/coverage/__root__', 'test/coverage/qunit' ], fs.readdir, function (err, files) {
+            assert.ok(files[0].indexOf('blogpost.js.html') >= 0, 'reports coverage of blogpost.js');
+            assert.ok(files[1].indexOf('test.js.html') >= 0, 'reports coverage of qunit/test.js');
+            done();
+        });
+      });
+    });
+  });
+
+  it('Jasmine example', function(done) {
+    del([ 'test/coverage' ]).then(function () {
+      testee.test([ 'jasmine/index.html' ], [ 'firefox' ], config).fail(function(error) {
+        assert.equal(error.message, 'There were 0 general errors and 1 total test failures.');
+
+        async.map([ 'test/coverage/__root__', 'test/coverage/jasmine' ], fs.readdir, function (err, files) {
+          assert.ok(files[0].indexOf('blogpost.js.html') >= 0, 'reports coverage of blogpost.js');
+          assert.ok(files[1].indexOf('test.js.html') >= 0, 'reports coverage of jasmine/test.js');
+          done();
+        });
+      });
+    });
+  });
+
+  it('Mocha example', function(done) {
+    del([ 'test/coverage' ]).then(function () {
+      testee.test([ 'mocha/index.html' ], [ 'firefox' ], config).fail(function() {
+        async.map([ 'test/coverage/__root__', 'test/coverage/mocha' ], fs.readdir, function (err, files) {
+          assert.ok(files[0].indexOf('blogpost.js.html') >= 0, 'reports coverage of blogpost.js');
+          assert.ok(files[1].indexOf('test.js.html') >= 0, 'reports coverage of mocha/test.js');
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/testee.test.js
+++ b/test/testee.test.js
@@ -3,36 +3,27 @@ var path = require('path');
 var testee = require('../lib/testee');
 
 describe('Testee', function() {
-  var oldLog;
   var config = {
+    reporter: 'Dot',
     root: path.join(__dirname, '..', 'examples')
   };
 
-  beforeEach(function() {
-    oldLog = console.log;
-    console.log = function() {};
-  });
-
-  afterEach(function() {
-    console.log = oldLog;
-  });
-
   it('QUnit example', function(done) {
-    testee.test([ 'qunit/index.html' ], [ 'phantom' ], config).fail(function(error) {
+    testee.test([ 'qunit/index.html' ], [ 'firefox' ], config).fail(function(error) {
       assert.equal(error.message, 'There were 0 general errors and 1 total test failures.');
       done();
     });
   });
 
   it('Jasmine example', function(done) {
-    testee.test([ 'jasmine/index.html' ], [ 'phantom' ], config).fail(function(error) {
+    testee.test([ 'jasmine/index.html' ], [ 'firefox' ], config).fail(function(error) {
       assert.equal(error.message, 'There were 0 general errors and 1 total test failures.');
       done();
     });
   });
 
   it('Mocha example', function(done) {
-    testee.test([ 'mocha/index.html' ], [ 'phantom' ], config).fail(function() {
+    testee.test([ 'mocha/index.html' ], [ 'firefox' ], config).fail(function() {
       done();
     });
   });


### PR DESCRIPTION
This will allow the use of the html coverage reporter. Here is an example config:

```
testee: {
    options: {
        root: './',
        coverage: {
            dir: 'test/coverage/',
            reporters: ['html']
        }
    },
    "unit-tests": ['test/test.html'],
}
```