### PR TITLE
Add system.npmDependencies to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "q": "^1.0.1",
     "testee-client": "^0.3.0",
     "useragent": "^2.0.9"
+  },
+  "system": {
+    "npmDependencies": []
   }
 }


### PR DESCRIPTION
This prevents steal from trying to load Testee's package.json files,
     preventing the need for projects (and the donejs generators) from
     having to add it to their own npmIgnore list.