### PR TITLE
Child process stdout buffers cut off in Node 4

### DIFF
--- a/bin/testee
+++ b/bin/testee
@@ -35,8 +35,8 @@ if(config.server) {
 } else {
   testee.test(program.args, browsers, config)
     .then(function() {
-      process.exit(0);
+      process.exitCode = 0;
     }, function() {
-      process.exit(1);
+      process.exitCode = 1;
     });
 }


### PR DESCRIPTION
In Node 4, a child process stdout/err buffers will be cut off if the process is terminated via process.exit(), and buffer writes are > 8K
Using process.exitCode instead, which lets the process end gracefully and complete the buffer flush
Issue discovered when executing a testee process with the JSON reporter, which was outputting ~14K of data

NOTE: This is not compatible with Node versions below v0.12.0 - would need a polyfill for older versions
Effect would be that Testee terminates with exit code zero in all cases on older Node versions

Relevant Node changelog: https://github.com/nodejs/node/wiki/API-changes-between-v0.10-and-v4#process