### PR TITLE
Update launchpad dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "feathers-memory": "^0.3.4",
     "http-proxy": "^1.1.4",
     "istanbul": "^0.4.0",
-    "launchpad": "^0.4.0",
+    "launchpad": "^0.5.1",
     "lodash": "^2.4.1",
     "mime-types": "^2.1.6",
     "miner": "^0.2.1",


### PR DESCRIPTION
Launchpad 0.5.1 has default phantomjs viewport size and that resolved https://github.com/bitovi/testee/issues/74