### PR TITLE
Testee will try to require mocha reporters if they are not in the lst of mocha reporters

### DIFF
--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -13,7 +13,17 @@ var testProperties = ['async', 'sync', 'timedOut', 'pending', 'file', 'duration'
 // The reporter listens to service events and reports it to the command line using
 // any of the Mocha reporters.
 function Reporter(MochaReporter, coverage, root) {
-  MochaReporter = typeof MochaReporter !== 'string' ? MochaReporter : mocha.reporters[MochaReporter];
+  if(typeof MochaReporter === 'string') {
+    if(mocha.reporters[MochaReporter]) {
+      MochaReporter = mocha.reporters[MochaReporter];
+    } else {
+      try {
+        MochaReporter = require(MochaReporter);
+      } catch (e) {
+        throw new Error('reporter "' + MochaReporter + '" does not exist');
+      }
+    }
+  }
 
   // The event emitter used to emit the final events
   var runner = this.runner = new EventEmitter();


### PR DESCRIPTION
If you specify a third party reporter like `mocha-bamboo-reporter`, you have to `require` it and pass it into Testee programtically. 

This PR replicates what mocha's [`_mocha`](https://github.com/mochajs/mocha/blob/master/bin/_mocha#L211) script does, where it tries to require a third party reporter if it isn't in the list.