### PR TITLE
Adding state to passed and failed tests so Mocha reporters work properly

### DIFF
--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -8,7 +8,7 @@ var debug = require('debug')('testee:reporter');
 
 var utils = require('../utils');
 var BufferManager = require('./buffer/manager');
-var testProperties = ['async', 'sync', 'timedOut', 'pending', 'file', 'duration'];
+var testProperties = ['async', 'sync', 'timedOut', 'pending', 'file', 'duration', 'state'];
 
 // The reporter listens to service events and reports it to the command line using
 // any of the Mocha reporters.
@@ -104,6 +104,7 @@ _.extend(Reporter.prototype, {
         id: utils.guid(),
         parent: id,
         status: 'failed',
+        state: 'failed',
         err: error,
         title: error.title || error.message
       };


### PR DESCRIPTION
Adding a state property to the test objects so mocha reporters can handle failed tests properly.

i.e The XUnit reporter adds a `<failure>` tag with a message [here](https://github.com/mochajs/mocha/blob/master/lib/reporters/xunit.js#L133) but only if `state === 'failed'`.