### PR TITLE
Allow reporting of client console logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can get more information about the available reporters in the [Reporters](#r
 
 ### Capturing `console.log` and `console.error`
 
-Testee tracks all calls to `console.log` and `console.error` in a test. To get the output during a test run, set the `DEBUG` environment vairable to `testee:console-log`:
+Testee tracks all calls to `console.log` and `console.error` in a test. To get the output during a test run, set the `DEBUG` environment variable to `testee:console-log`:
 
 > `DEBUG=testee:console-log testee --browsers canary tests/jasmine.html`
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ the result XML into `testresults.xml`:
 You can get more information about the available reporters in the [Reporters](#reporters) section.
 
 
+### Capturing `console.log` and `console.error`
+
+Testee tracks all calls to `console.log` and `console.error` in a test. To get the output during a test run, set the `DEBUG` environment vairable to `testee:console-log`:
+
+> `DEBUG=testee:console-log testee --browsers canary tests/jasmine.html`
+
 ### Debugging
 
 Testee uses the Node [debug](https://github.com/visionmedia/debug) module. Detailed debugging information can be enabled

--- a/examples/mocha/test.js
+++ b/examples/mocha/test.js
@@ -4,6 +4,8 @@ describe('BlogPost test', function() {
 		const now = new Date(),
 			post = new BlogPost('Hello', 'Hello world', now);
 		assert(post.date.getTime() == now.getTime());
+
+		console.log('Hi there!');
 	});
 
 	it('Should throw an exception', function() {
@@ -28,6 +30,8 @@ describe('BlogPost test', function() {
 				"<p>Hello world</p>");
 			done();
 		});
+
+		console.error('Blog post is', newpost);
 	});
 
   it.skip('This is a skipped test', function() {

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -6,6 +6,7 @@ var useragent = require('useragent');
 var istanbul = require('istanbul');
 var path = require('path');
 var debug = require('debug')('testee:reporter');
+var logDebug = require('debug')('testee:console-log');
 
 var utils = require('../utils');
 var BufferManager = require('./buffer/manager');
@@ -47,7 +48,7 @@ function Reporter(MochaReporter, coverage, root) {
 _.extend(Reporter.prototype, {
   // Called when the Feathers application is set up with the event
   // services for runs, suites and tests (which are event emitters)
-  setup: function(runs, suites, tests, coverages) {
+  setup: function(runs, suites, tests, coverages, logs) {
     debug('setting up Mocha command line reporter');
 
     runs.on('error', this.proxy('error'));
@@ -60,6 +61,8 @@ _.extend(Reporter.prototype, {
 
     tests.on('created', this.proxy('startTest'));
     tests.on('patched', this.proxy('updateTest'));
+
+    logs.on('created', this.proxy('captureLog'));
 
     coverages.on('created', this.proxy('reportCoverage'));
 
@@ -273,6 +276,10 @@ _.extend(Reporter.prototype, {
     reporter.write(collector, true, function () {
       debug('reportCoverage() coverage written to ' + options.dir);
     });
+  },
+
+  captureLog: function(log) {
+    logDebug('(' + log.parent + ') console.' + log.type, log.args);
   }
 });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,7 +18,8 @@ var api = exports.api = function() {
     .use('/runs', memory())
     .use('/suites', memory())
     .use('/tests', memory())
-    .use('/coverages', memory());
+    .use('/coverages', memory())
+    .use('/logs', memory());
 };
 
 // Returns an Express application that hosts a Testee server with the given options:

--- a/lib/testee.js
+++ b/lib/testee.js
@@ -33,7 +33,7 @@ _.extend(Testee.prototype, {
         // Bind Feathers service .lookup
         var lookup = self.api.service.bind(self.api);
         debug('hooking up services to Mocha reporter');
-        reporter.setup(lookup('runs'), lookup('suites'), lookup('tests'), lookup('coverages'));
+        reporter.setup(lookup('runs'), lookup('suites'), lookup('tests'), lookup('coverages'), lookup('logs'));
 
         self.reporter = reporter;
       })

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mocha": "^3.2.0",
     "path": "^0.12.7",
     "q": "^1.0.1",
-    "testee-client": "^0.4.0-pre.1",
+    "testee-client": "^0.5.0",
     "useragent": "^2.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request adds the server side functionality to keep track of browser console.logs:

<img width="1063" alt="screen shot 2017-04-27 at 10 37 27 am" src="https://cloud.githubusercontent.com/assets/338316/25496685/b5259bc6-2b36-11e7-839a-7621585fc626.png">

Closes #8, closes #109