### PR TITLE
Make package.json license a valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,7 @@
     "testing",
     "unit-test"
   ],
-  "license": {
-    "name": "MIT",
-    "url": "http://www.opensource.org/licenses/mit-license.php"
-  },
+  "license": "MIT",
   "main": "lib/testee.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `license` should be a string.