### PR TITLE
Add warning/autofix for missing doctype

### DIFF
--- a/lib/host/inject.js
+++ b/lib/host/inject.js
@@ -4,28 +4,55 @@ var path = require('path');
 var url = require('url');
 var mime = require('mime-types');
 
+function includes(str, search) {
+  return str.indexOf(search) != -1;
+}
+
+function ensureDoctype(html) {
+  const hasDoctype = includes(html, '<!doctype') || includes(html, '<!DOCTYPE');
+  if (hasDoctype) {
+    return html;
+  }
+
+  console.warn('Doctype not found; injecting <!doctype html> to prevent quirksmode problems');
+  return '<!doctype html>' + html;
+}
+
+function injectScript(html, scriptUrl) {
+  if (includes(html, scriptUrl)) {
+    console.warn('Script "' + scriptUrl + '" will be auto-injected; please do not include it yourself');
+    return html;
+  }
+
+  const script = '<script type="text/javascript" src="' + scriptUrl + '"></script>';
+
+  const hasBodyEnd = includes(html, '</body>');
+  if (hasBodyEnd) {
+    return html.replace('</body>', script + '</body>');
+  }
+
+  return html + script;
+}
+
+function buildScriptUrl(config) {
+  return config.adapter + 'testee.min.js';
+}
+
 // Returns a middleware that injects the SocketIO JavaScript
 // and a link to the clients side adapters into any HTML file
-module.exports = function(configuration) {
-  return injector(function(req, res) {
+module.exports = function (configuration) {
+  return injector(function (req, res) {
     var header = res.getHeader('content-type') || mime.contentType(path.extname(url.parse(req.url).pathname));
-    if(res._header) {
+    if (res._header) {
       var matches = res._header.match(/content-type:[\s*](.*)/i);
       header = matches && matches[1];
     }
     return header && (header.indexOf('text/html') === 0);
-  }, function(data, req, res, callback) {
+  }, function (data, req, res, callback) {
     debug('injecting scripts into file', req.url);
     var html = data.toString();
-    var scripts = '<script type="text/javascript" src="' +
-      configuration.adapter + 'testee.min.js"></script>\n';
-    
-    if(html.indexOf('</body>') !== -1) {
-      html = data.toString().replace('</body>', scripts + '</body>');
-    } else if(html.indexOf('</script>') !== -1) {
-      html += scripts;
-    }
-
+    html = ensureDoctype(html);
+    html = injectScript(html, buildScriptUrl(configuration));
     callback(null, html);
   });
 };

--- a/lib/host/inject.js
+++ b/lib/host/inject.js
@@ -9,12 +9,12 @@ function includes(str, search) {
 }
 
 function ensureDoctype(html) {
-  const hasDoctype = includes(html, '<!doctype') || includes(html, '<!DOCTYPE');
+  var hasDoctype = includes(html, '<!doctype') || includes(html, '<!DOCTYPE');
   if (hasDoctype) {
     return html;
   }
 
-  console.warn('Doctype not found; injecting <!doctype html> to prevent quirksmode problems');
+  console.warn('Doctype not found; prepending "<!doctype html>" to prevent quirksmode problems');
   return '<!doctype html>' + html;
 }
 
@@ -24,9 +24,9 @@ function injectScript(html, scriptUrl) {
     return html;
   }
 
-  const script = '<script type="text/javascript" src="' + scriptUrl + '"></script>';
+  var script = '<script type="text/javascript" src="' + scriptUrl + '"></script>';
 
-  const hasBodyEnd = includes(html, '</body>');
+  var hasBodyEnd = includes(html, '</body>');
   if (hasBodyEnd) {
     return html.replace('</body>', script + '</body>');
   }
@@ -55,4 +55,12 @@ module.exports = function (configuration) {
     html = injectScript(html, buildScriptUrl(configuration));
     callback(null, html);
   });
+};
+
+// for testing
+module.exports._testing = {
+  includes: includes,
+  ensureDoctype: ensureDoctype,
+  injectScript: injectScript,
+  buildScriptUrl: buildScriptUrl
 };

--- a/test/host.test.js
+++ b/test/host.test.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var inject = require('../lib/host/inject');
+
+describe('inject.js', function () {
+    var testing = inject._testing;
+    var ensureDoctype = testing.ensureDoctype;
+    var injectScript = testing.injectScript;
+
+    describe('ensureDoctype()', function () {
+        it('should prepend a doctype if not included in the html', function () {
+            var html = 'This is fine.';
+            assert.equal(
+                ensureDoctype(html),
+                '<!doctype html>This is fine.'
+            );
+        });
+
+        it('should not modify an existing doctype', function () {
+            var lowerHtml = '<!doctype transitional>';
+            var upperHtml = '<!DOCTYPE super-strict>';
+            assert.equal(ensureDoctype(lowerHtml), lowerHtml);
+            assert.equal(ensureDoctype(upperHtml), upperHtml);
+        });
+    });
+
+    describe('injectScript()', function () {
+        it('should append scripts when there is no body tag', function () {
+            var html = 'The text file thing';
+            var scriptSrc = 'foo.js';
+            var scriptTag = '<script type="text/javascript" src="' + scriptSrc + '"></script>';
+            assert.equal(injectScript(html, 'foo.js'), html + scriptTag);
+        });
+
+        it('should place scripts right before the closing body tag', function () {
+            var html = '<body>The text file thing</body>';
+            var scriptSrc = 'foo.js';
+            var scriptTag = '<script type="text/javascript" src="' + scriptSrc + '"></script>';
+            assert.equal(
+                injectScript(html, 'foo.js'),
+                '<body>The text file thing' + scriptTag + '</body>'
+            );
+        });
+    });
+});


### PR DESCRIPTION
Fixes #110 

Adds a warning that the doctype is missing and injects `<!doctype html>` in that case.

Another warning is also added if someone manually adds the testee client file in case they misunderstand how the auto-injection is working.