### PR TITLE
Deprecate grunt task

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 - Code coverage
 - Local and remote file testing
 
-
 ## Installation
 
 [Node.js](http://nodejs.org/) `>= 4` is required. To install, type this at the command line:
@@ -91,34 +90,7 @@ testee.test(files, browsers, config)
 
 ## Grunt Usage
 
-This package comes with a [grunt](https://npmjs.com/grunt) task that extends the [configuration API](#configuration-api):
-
-```js
-module.exports = function(grunt) {
-  grunt.initConfig({
-    testee: {
-      options: {
-        // See configuration API
-      },
-      coverage: {
-        options: {
-          // See configuration API
-        },
-        src: ['test/index.html']
-      },
-      browserstack: {
-        options: {
-          // See configuration API
-        },
-        src: ['test/index.html']
-      }
-    }
-  });
-
-  grunt.loadNpmTasks('testee');
-};
-```
-
+See the [Testee Grunt plugin `grunt-testee`](https://github.com/bitovi/grunt-testee) for more information.
 
 ## Configuration API
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "feathers-memory": "^1.0.1",
     "feathers-rest": "^1.5.0",
     "feathers-socketio": "^1.4.1",
+    "grunt-testee": "^1.0.0",
     "http-proxy": "^1.1.4",
     "istanbul": "^0.4.0",
     "launchpad": "^0.5.1",

--- a/tasks/testee.js
+++ b/tasks/testee.js
@@ -1,33 +1,7 @@
-var path = require('path');
-var testee = require('../lib/testee');
-
-module.exports = function (grunt) {
-  grunt.registerMultiTask('testee', 'Run tests', function () {
-    var done = this.async();
-    var options = this.options();
-    var browsers = options.browsers || ['phantom'];
-    var files = grunt.file.expand(grunt.util._.flatten(this.files.map(function (file) {
-      // Test file path need to be absolute to the root so that grunt.file.expand can glob them
-      return file.orig.src;
-    })).map(function(filename) {
-      return path.join(options.root || '', filename);
-    }));
-
-    if(options.root) {
-      // Each file in the globbed list needs to be converted back to their relative paths
-      files = files.map(function (file) {
-        return path.relative(options.root || '', file);
-      });
-    }
-
-    if(!files.length) {
-      return done(new Error('No file passed to Testee task.'));
-    }
-
-    testee.test(files, browsers, options).then(function () {
-      done();
-    }, function (error) {
-      done(error);
-    });
-  });
-};
+console.warn([
+  'DEPRECATION:',
+  'The Testee Grunt task has been moved to its own project and will be removed in testee@0.7.0.',
+  '\nTo migrate, please run `npm install --save-dev grunt-testee`',
+  'and replace `grunt.loadNpmTasks("testee");` with `grunt.loadNpmTasks("grunt-testee");`.',
+].join(' '))
+module.exports = require('grunt-testee');


### PR DESCRIPTION
Closes #124. Note that the task is not removed but has been split up, v0.7.0 will remove it completely.