### PR TITLE
not instrumenting node_modules when using the basic `--coverage` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Type: `Array`
 Default value: `['text']`  
 A list of regex patterns that match files to be ignored by coverage instrumentation and reporting.
 
+**Note:** When using the `--coverage` option, `coverage.ignore` will default to `['node_modules']`.
+
 #### `coverage.reporters`
 Type: `Array`  
 Default value: `[]`  

--- a/bin/testee
+++ b/bin/testee
@@ -30,6 +30,10 @@ config = _.extend(config, _.pick(program, 'browsers', 'port', 'root', 'reporter'
 var browsers = _.isArray(config.browsers) ? config.browsers :
   (config.browsers || 'phantom').split(',');
 
+// passing `--coverage` will not instrument node_modules by default
+config.coverage = config.coverage !== true ? config.coverage :
+	{ ignore: [ "node_modules" ] };
+
 if(config.server) {
   testee.server(config);
 } else {

--- a/lib/testee.js
+++ b/lib/testee.js
@@ -78,7 +78,7 @@ _.extend(Testee.prototype, {
   },
 
   startServer: function () {
-    debug('starting testee server', this.options);
+    debug('starting testee server with options:', JSON.stringify(this.options, null, '\t'));
     return createServer(this.options).then(function (server) {
       debug('testee server started and listening on port ' + this.options.port);
       this.server = server;


### PR DESCRIPTION
If you use the `--coverage` option, the `node_modules` folder will be ignored automatically to prevent errors.

If using a config, the `coverage` option is not changed, so you can still cover `node_modules` if you want to for some reason by doing:
```
coverage: {
  ignore: []
}
```

Closes #169.