### PR TITLE
Add --no-sandbox flag to headless Chrome instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ A simple, local browser config (JSON) example with mostly default values could l
       "args": [
         "--headless",
         "--disable-gpu",
+        "--no-sandbox",
         "--remote-debugging-port=9222"
       ]
     }
@@ -204,6 +205,7 @@ The browsers that will be used to run tests. For local browsers, use a browser n
   "args": [
     "--headless",
     "--disable-gpu",
+    "--no-sandbox",
     "--remote-debugging-port=9222"
   ]
 }
@@ -287,6 +289,7 @@ module.exports = {
   "args": [
     "--headless",
     "--disable-gpu",
+    "--no-sandbox",
     "--remote-debugging-port=9222"
   ]
 }


### PR DESCRIPTION
The `--no-sandbox` flag is required to get headless Chrome to launch on Travis by default.

I think the alternative is to add docs on setting up a user so the sandbox works correctly; see https://developers.google.com/web/updates/2017/04/headless-chrome for more details.