### PR TITLE
Add stats object to mocha runner

### DIFF
--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 var mocha = require('mocha');
+var createStatsCollector = require('mocha/lib/stats-collector');
 var url = require('url');
 var EventEmitter = require('events').EventEmitter;
 var useragent = require('useragent');
@@ -29,6 +30,10 @@ function Reporter(MochaReporter, coverage, root, reporterOptions) {
 
   // The event emitter used to emit the final events
   var runner = this.runner = new EventEmitter();
+  if (!runner.stats) {
+    createStatsCollector(runner);
+  }
+
   // A store (by data GUID) for the Mocha objects we created.
   // The handler for buffering simultaneous test runs
   this.buffers = new BufferManager(runner);


### PR DESCRIPTION
I don't know the root of the problem but the stealjs build was failing because of the stats collector missing from the runner when grunt-testee runs testee.  This PR will fix that particular issue by ensuring stats exist.